### PR TITLE
Bumped poetry version up to support the more modern: poetry.core.masonry.api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,5 @@ flake8 = "^3.8.3"
 isort = "^4.3.21"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry>=1.0.9"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Bumped poetry version up to support the more modern: poetry.core.masonry.api

See: https://github.com/python-poetry/poetry/blob/7243b94109a5185642a576a498d932ccc9e829f3/CHANGELOG.md?plain=1#L1167