### PR TITLE
Change Field to TextField

### DIFF
--- a/django_hashids/field.py
+++ b/django_hashids/field.py
@@ -1,13 +1,13 @@
 from django.conf import settings
 from django.core.exceptions import FieldError
-from django.db.models import Field
+from django.db.models import TextField
 from django.utils.functional import cached_property
 from hashids import Hashids
 
 from .exceptions import ConfigError, RealFieldDoesNotExistError
 
 
-class HashidsField(Field):
+class HashidsField(TextField):
     concrete = False
     allowed_lookups = ("exact", "iexact", "in", "gt", "gte", "lt", "lte", "isnull")
     # these should never change, even when Hashids updates
@@ -22,7 +22,7 @@ class HashidsField(Field):
         salt=None,
         alphabet=None,
         min_length=None,
-        **kwargs
+        **kwargs,
     ):
         kwargs.pop("editable", None)
         super().__init__(*args, editable=False, **kwargs)

--- a/django_hashids/field.py
+++ b/django_hashids/field.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import FieldError
-from django.db.models import TextField
+from django.db.models import TextField, Field
 from django.utils.functional import cached_property
 from hashids import Hashids
 


### PR DESCRIPTION
While trying to use `HashidsField` with DRF and django-spectacular (DS) (an OpenAPI schema generator for DRF), I got errors which accused `HashidsField` of not mapping correctly into any specific OpenAPI type.

This stems from the fact that `HashidsField`, while for all intents and purposes acts like a `str`, does not have a way to tell this to DS. A simple fix would be to make `HashidsField` inherit from `TextField` instead of `Field`. I believe this is correct but I'm open to feedback.

I'm not familiar enough with the django ecosystem to understand how to run the tests from this repo, but at a first glance, basic queries worked flawlessly in my project.